### PR TITLE
購入済み商品の「編集・削除」ボタンを非表示に修正

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,9 +28,11 @@
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id %>
-        <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
-        <p class='or-text'>or</p>
-        <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
+        <% unless @item.purchased_item %>
+          <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
+          <p class='or-text'>or</p>
+          <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
+        <% end %>
       <% else @item.purchased_item == nil %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
         <% unless @item.purchased_item %>


### PR DESCRIPTION
#What
・出品者が購入済み商品の詳細ページに遷移した際の、「編集・削除」ボタンを非表示にする

#Why
商品詳細表示機能実装のため